### PR TITLE
Allow both apt & pip installs for python in Dockerfile using ENV flag

### DIFF
--- a/helm-base-versions/Dockerfile
+++ b/helm-base-versions/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.18.5
 
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
+
 RUN apk add curl coreutils yq jq openssl uuidgen bash helm
 
 COPY helm-chart-base-versions.sh /


### PR DESCRIPTION
### Jira link (if applicable)

fix issue with python by enabling system & pip package manager installations using ENV flag - see [here](https://veronneau.org/python-311-pip-and-breaking-system-packages.html) for info

https://github.com/hmcts/azure-cftapps-monitoring/actions/runs/10250412409/job/28358659487

### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
