### PR TITLE
Allow both apt & pip installs for python in Dockerfile using ENV for failed deployment 

### DIFF
--- a/failed-deployments/Dockerfile
+++ b/failed-deployments/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.18.5
 
+ENV PIP_BREAK_SYSTEM_PACKAGES 1
+
 RUN apk add curl coreutils yq jq openssl uuidgen bash helm
 
 RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \


### PR DESCRIPTION
### Jira link (https://tools.hmcts.net/jira/browse/DTSPO-14630)


https://github.com/hmcts/azure-cftapps-monitoring/actions/runs/10251553263/job/28359892217


### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
